### PR TITLE
fixing images

### DIFF
--- a/_include/support-registration.adoc
+++ b/_include/support-registration.adoc
@@ -68,7 +68,7 @@ If you are brand new to NetApp and you don't have an NSS account, follow each st
 
 . Locate your account ID serial number from the Support Registration page.
 +
-image:https://raw.githubusercontent.com/NetAppDocs/bluexp-family/main/media/screenshot-serial-number.png[A screenshot of the Help menu where Support is the first option listed]
+image:https://raw.githubusercontent.com/NetAppDocs/console-family/main/media/screenshot-serial-number.png[A screenshot of the Help menu where Support is the first option listed]
 
 . Navigate to https://register.netapp.com[NetApp's support registration site^] and select *I am not a registered NetApp Customer*.
 
@@ -122,7 +122,7 @@ These NSS credentials are associated with your specific Console account ID. User
  
 . In the upper right of the Console, select the Help icon, and select *Support*.
 +
-image:https://raw.githubusercontent.com/NetAppDocs/bluexp-family/main/media/screenshot-help-support.png[A screenshot of the Help menu where Support is the first option listed]
+image:https://raw.githubusercontent.com/NetAppDocs/console-family/main/media/screenshot-help-support.png[A screenshot of the Help menu where Support is the first option listed]
 
 . Select *NSS Management > Add NSS Account*.
 
@@ -146,8 +146,8 @@ The same is true if you have pre-existing customer-level NSS accounts and try to
 
 * Upon successful login, NetApp will store the NSS user name. 
 +
-This is a system-generated ID that maps to your email. On the *NSS Management* page, you can display your email from the image:https://raw.githubusercontent.com/NetAppDocs/bluexp-family/main/media/icon-nss-menu.png[An icon of three horizontal dots] menu.
+This is a system-generated ID that maps to your email. On the *NSS Management* page, you can display your email from the image:https://raw.githubusercontent.com/NetAppDocs/console-family/main/media/icon-nss-menu.png[An icon of three horizontal dots] menu.
 
-* If you ever need to refresh your login credential tokens, there is also an *Update Credentials* option in the image:https://raw.githubusercontent.com/NetAppDocs/bluexp-family/main/media/icon-nss-menu.png[An icon of three horizontal dots] menu. 
+* If you ever need to refresh your login credential tokens, there is also an *Update Credentials* option in the image:https://raw.githubusercontent.com/NetAppDocs/console-family/main/media/icon-nss-menu.png[An icon of three horizontal dots] menu. 
 +
 Using this option prompts you to log in again. Note that the token for these accounts expire after 90 days. A notification will be posted to alert you of this.


### PR DESCRIPTION
This pull request updates image links in the support registration documentation to reference the `console-family` repository instead of `bluexp-family`. This ensures that the images reflect the correct and current UI for the Console product.

Documentation updates:

* Updated image links in `_include/support-registration.adoc` to use the `console-family` repository for screenshots and icons, replacing previous references to `bluexp-family`. [[1]](diffhunk://#diff-f1907d780f125a9761eac1d4be4ad2785350b704762f463f37bb510b50726344L71-R71) [[2]](diffhunk://#diff-f1907d780f125a9761eac1d4be4ad2785350b704762f463f37bb510b50726344L125-R125) [[3]](diffhunk://#diff-f1907d780f125a9761eac1d4be4ad2785350b704762f463f37bb510b50726344L149-R151)